### PR TITLE
Add support for Regional Control Planes

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,5 +110,5 @@ Once deployed, you can expect your resource group to look like the example below
 
 ![StrongDM Permissions](doc/partnertraining.png?raw=true)
 ## Issues, comments, feedback
-This repository is maintained with :blue_heart: by @HameArm, @ncorrare and other members of the @StrongDM team.
+This repository is maintained with :blue_heart: by [Hamish](https://github.com/HameArm), [Nico](https://github.com/ncorrare) and other members of the [StrongDM](https://github.com/strongdm) team.
 Please send us your issues and PR through the GitHub functionality, and we will get to them as soon as possible.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repository contains a set of modules that enable the user to deploy a quick
 - A Windows domain controller 
 - A Windows server target using certificate authentication 
 - An AKS Cluster 
+- A HashiCorp Vault single instance cluster
 
 All resources are tagged according to variables set in the module, in order to set adequate access roles in StrongDM
 
@@ -32,13 +33,27 @@ or in Powershell
 $env:SDM_API_ACCESS_KEY="auth-xxxxxx888x8x88x8x6"
 $env:SDM_API_SECRET_KEY="X4fasfasfasfasfasfsafaaqED34ge5343CkQ"
 ```
+
+> [!NOTE]
+> If your control plane is in the UK, or the EU, make sure that the SDM_HOST_API variable is correctly set.
+> Gateways and relays *will* use this variable as well to register against the right tenant
+
+```bash
+export SDM_API_HOST=api.uk.strongdm.com:443
+```
+or in Powershell
+```powershell
+$env:SDM_API_HOST="api.uk.strongdm.com:443"
+```
+
+Make sure you're logged into sdm with a user that has enough privilege to read the CA certifcate for Windows:
+```sdm login
+sdm admin rdp view-ca
+```
+
 > [!NOTE]
 > The verification of the operating system is done based on the presence of "c:" in the module path. If there is no c:,
 > the module will not assume you're using Windows.
-
-Make sure you're logged into sdm with 
-```sdm login```
-specially if you're using the Windows CA target, as it will use the local process to pull the Windows CA Certificate
 
 ## Variables
 - Network
@@ -57,6 +72,7 @@ The module will not verify if the right network configuration is set so make sur
   - create_domain_controller: Create a Windows Domain Controller
   - create_windows_target: Create a Windows RDP target
   - create_az_ro: Create a service principal to be used to access Azure with read only privileges. Passwords expire every 10 days so you'll need to re-run ```terraform apply``` to update the password in StrongDM
+  - create_hcvault: Deploy a single instance HashiCorp Vault and have the gateway authenticate using it's own managed identity into it. By default it will get all privileges into the kv/ path
  
 - Other Variables:
   - tagset: tags to apply to all resources
@@ -71,6 +87,7 @@ Within the main module, do the usual steps
 
 ```bash
 cd main
+cp terraform.tfvars.example terraform.tfvars
 terraform init
 terraform plan
 terraform apply
@@ -92,3 +109,6 @@ This means that of cource that you cannot deploy the "Windows target" until the 
 Once deployed, you can expect your resource group to look like the example below
 
 ![StrongDM Permissions](doc/partnertraining.png?raw=true)
+## Issues, comments, feedback
+This repository is maintained with :blue_heart: by @HameArm, @ncorrare and other members of the @StrongDM team.
+Please send us your issues and PR through the GitHub functionality, and we will get to them as soon as possible.

--- a/main/gateway.tf
+++ b/main/gateway.tf
@@ -61,6 +61,7 @@ resource "azurerm_linux_virtual_machine" "sdmgw" {
     sdm_relay_token    = sdm_node.gateway.gateway[0].token
     target_user        = "azureuser"
     vault_ip           = ""
+    sdm_domain         = element(split(":", data.env_var.sdm_api.value), 0)
     }
    )
   )

--- a/main/gateway.tf
+++ b/main/gateway.tf
@@ -61,7 +61,8 @@ resource "azurerm_linux_virtual_machine" "sdmgw" {
     sdm_relay_token    = sdm_node.gateway.gateway[0].token
     target_user        = "azureuser"
     vault_ip           = ""
-    sdm_domain         = element(split(":", data.env_var.sdm_api.value), 0)
+    #sdm_domain         = element(split(":", data.env_var.sdm_api.value), 0)
+    sdm_domain         = join(".", slice(split(".", element(split(":", data.env_var.sdm_api.value), 0)), 1, length(split(".", element(split(":", data.env_var.sdm_api.value), 0)))))
     }
    )
   )

--- a/main/gateway.tf
+++ b/main/gateway.tf
@@ -62,7 +62,7 @@ resource "azurerm_linux_virtual_machine" "sdmgw" {
     target_user        = "azureuser"
     vault_ip           = ""
     #sdm_domain         = element(split(":", data.env_var.sdm_api.value), 0)
-    sdm_domain         = join(".", slice(split(".", element(split(":", data.env_var.sdm_api.value), 0)), 1, length(split(".", element(split(":", data.env_var.sdm_api.value), 0)))))
+    sdm_domain         = data.env_var.sdm_api.value == "" ? "" : coalesce(join(".", slice(split(".", element(split(":", data.env_var.sdm_api.value), 0)), 1, length(split(".", element(split(":", data.env_var.sdm_api.value), 0))))),"")
     }
    )
   )

--- a/main/gw-provision.tpl
+++ b/main/gw-provision.tpl
@@ -10,7 +10,12 @@ curl -J -O -L https://app.strongdm.com/releases/cli/linux && unzip sdmcli* && rm
 systemctl disable ufw.service
 systemctl stop ufw.service
 # Install SDM
-sudo ./sdm install --relay --token=$SDM_RELAY_TOKEN --user=$TARGET_USER | logger -t sdminstall
+%{ if sdm_domain != "" }
+sudo ./sdm install --relay --token=$SDM_RELAY_TOKEN --user=$TARGET_USER --domain=${sdm_domain}| logger -t sdminstall
+%{ endif }
+%{ if sdm_domain == "" }
+sudo ./sdm install --relay --token=$SDM_RELAY_TOKEN --user=$TARGET_USER| logger -t sdminstall
+%{ endif }
 %{ if vault_ip != "" }
 JWT=$(curl -s 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F' -H Metadata:true | jq -r '.access_token')
 RG=$(curl -s -H Metadata:true "http://169.254.169.254/metadata/instance?api-version=2017-08-01" | jq -r .compute.resourceGroupName)

--- a/main/relay.tf
+++ b/main/relay.tf
@@ -47,6 +47,7 @@ resource "azurerm_linux_virtual_machine" "sdmrelay" {
     sdm_relay_token    = sdm_node.relay.relay[0].token
     target_user        = "azureuser"
     vault_ip           = one(module.hcvault[*].ip)
+    sdm_domain         = element(split(":", data.env_var.sdm_api.value), 0)
     }
    )
   )

--- a/main/relay.tf
+++ b/main/relay.tf
@@ -47,7 +47,7 @@ resource "azurerm_linux_virtual_machine" "sdmrelay" {
     sdm_relay_token    = sdm_node.relay.relay[0].token
     target_user        = "azureuser"
     vault_ip           = one(module.hcvault[*].ip)
-    sdm_domain         = element(split(":", data.env_var.sdm_api.value), 0)
+    sdm_domain         = join(".", slice(split(".", element(split(":", data.env_var.sdm_api.value), 0)), 1, length(split(".", element(split(":", data.env_var.sdm_api.value), 0)))))
     }
    )
   )

--- a/main/relay.tf
+++ b/main/relay.tf
@@ -46,8 +46,8 @@ resource "azurerm_linux_virtual_machine" "sdmrelay" {
   user_data             = base64encode(templatefile("${path.module}/gw-provision.tpl", {
     sdm_relay_token    = sdm_node.relay.relay[0].token
     target_user        = "azureuser"
-    vault_ip           = one(module.hcvault[*].ip)
-    sdm_domain         = join(".", slice(split(".", element(split(":", data.env_var.sdm_api.value), 0)), 1, length(split(".", element(split(":", data.env_var.sdm_api.value), 0)))))
+    vault_ip           = var.create_hcvault == false ? "" : one(module.hcvault[*].ip)
+    sdm_domain         = data.env_var.sdm_api.value == "" ? "" : coalesce(join(".", slice(split(".", element(split(":", data.env_var.sdm_api.value), 0)), 1, length(split(".", element(split(":", data.env_var.sdm_api.value), 0))))),"")
     }
    )
   )

--- a/main/terraform.tf
+++ b/main/terraform.tf
@@ -11,6 +11,9 @@ terraform {
     azuread = {
       source = "hashicorp/azuread"
     }
+    env = {
+      source = "tcarreira/env"
+    }
   }
 
   required_version = ">= 1.1.0"
@@ -34,3 +37,7 @@ provider "azuread" {}
 data "azurerm_subscription" "subscription" {}
 
 data "azurerm_client_config" "current" {}
+
+data "env_var" "sdm_api" {
+  id = "SDM_API_HOST"
+}


### PR DESCRIPTION
The following changeset implements reading the SDM_API_HOST environment variable and based on that registers the gateways and relays in the right control plane